### PR TITLE
Fix for the crash of flye_medaka_workflow when running the POLISH workflow

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,3 +11,4 @@ dependencies:
   - prokka
   - bakta
   - roary
+  - python

--- a/envs/medaka.yml
+++ b/envs/medaka.yml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - medaka
+  - ont-fast5-api


### PR DESCRIPTION
In its current state, the workflow crashes when going through POLISH. Medaka tries to call python, which expects to be in the `bin/` directory of the conda environment. But there is no `python` binary or link in `bin/`. Adding `python` to `environment.yml` fixes this problem.

Medaka also needs the python module `ont_fast5_api`, which is not currently listed as a dependency. So `envs\medaka.yml` now includes `ont-fast5-api`. Note that if `python` is added to `envs\medaka.yml`, medaka is still unable to find `ont_fast_api` somehow. If `python` is added to `environment.yml`, the module loads.


With these two changes, the nextflow command listed in the onboarding tutorial works just fine.